### PR TITLE
chore: sync main into develop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/ @preprio/security-team
+.trivyignore @preprio/security-team


### PR DESCRIPTION
This PR syncs `main` into `develop` because `main` is ahead with changes.

- Detected ahead commits: 2
